### PR TITLE
If no match, clarify which user's message we looked at.

### DIFF
--- a/src/substitute.coffee
+++ b/src/substitute.coffee
@@ -62,7 +62,7 @@ module.exports = (robot) ->
 
       # nothing was replaced, regex didn't match
       if ( replaceText == origText ) 
-        msg.send("#{username}: There is no substitute for trying")
+        msg.send("#{username}: Hmm, that didn't match your last message.")
 
       # display new text
       else
@@ -101,7 +101,7 @@ module.exports = (robot) ->
 
       # nothing was replaced, regex didn't match
       if ( replaceText == origText ) 
-        msg.send("#{username}: There is no substitute for trying")
+        msg.send("#{username}: Hmm, that didn't the last message by #{userId}.")
 
       # display new text
       else


### PR DESCRIPTION
I got rather confused with hubot-substitute, expecting behaviour like this:

```
Alice> what editor do you prefer?
Bob> I'm a Vim guy
Alice> s/a Vim/an Emacs/
Hubot> Bob: I'm an Emacs guy
```

However, the regex will actually be applied to Alice's message, leading to some confusion:

```
Alice> what editor do you prefer?
Bob> I'm a Vim guy
Alice> s/a Vim/an Emacs/
Hubot> Alice: There is no substitute for trying
```

This PR improves the error message to clarify which message Hubot looked at.
